### PR TITLE
Add JWT-based authentication and login UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,21 @@ Your Express app will be running at [http://localhost:3000](http://localhost:300
   docker-compose -f .devcontainer/docker-compose.yml down -v
   docker-compose -f .devcontainer/docker-compose.yml up -d db
   ```
+
+### Authentication environment variables
+
+Create a `.env` file in the project root (or update your existing file) and provide the following values so that JWT authentication can work:
+
+```
+PGHOST=localhost
+PGUSER=dev
+PGPASSWORD=dev
+PGDATABASE=campusWell
+PGPORT=5432
+JWT_SECRET=change-me
+# Optional:
+# JWT_EXPIRES_IN=1h
+# JWT_COOKIE_MAX_AGE_MS=3600000
+```
+
+`JWT_SECRET` must be a sufficiently random string; update it in production to keep issued tokens secure.

--- a/app.js
+++ b/app.js
@@ -1,12 +1,16 @@
 import express from 'express';
 import debug from 'debug';
+import dotenv from 'dotenv';
 import * as server from './config/server.js';
 import { homeRouter } from './routes/home.js';
 import { moodTrackingRouter } from './routes/moodTracking.js';
+import { authRouter } from './routes/auth.js';
+import { attachUser } from './middleware/auth.js';
 // Setup debug module to spit out all messages
 // Do `npn start` to see the debug messages
 export const codeTrace = debug("comp3028:server");
 // Start the app
+dotenv.config();
 export const app = express();
 server.setup(app);
 // Register any middleware here
@@ -15,11 +19,13 @@ app.use((req, res, next) => {
   res.locals.currentPath = req.path;
   next();
 });
+app.use(attachUser);
 // Register routers here
-app.use('/', homeRouter);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.set("view engine", "ejs");
+app.use('/', homeRouter);
+app.use('/auth', authRouter);
 app.use("/moodTracking",moodTrackingRouter);
 // Not encouraged, but this is a simple example of how to register a route without a router.
 app.get("/test", (req, res) => {

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -1,0 +1,137 @@
+import bcrypt from 'bcryptjs';
+import jwt from 'jsonwebtoken';
+import pool from '../db/db.js';
+import { safeRedirect } from '../middleware/auth.js';
+
+const TOKEN_COOKIE_NAME = 'token';
+const DEFAULT_EXPIRY = '1h';
+
+function wantsJSON(req) {
+  const accept = req.headers.accept || '';
+  const contentType = req.headers['content-type'] || '';
+  return accept.includes('application/json') || contentType.includes('application/json');
+}
+
+function createTokenPayload(user) {
+  return {
+    id: user.id,
+    email: user.email,
+    fullName: user.full_name,
+    role: user.role,
+  };
+}
+
+function signToken(payload) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET is not configured');
+  }
+  const expiresIn = process.env.JWT_EXPIRES_IN || DEFAULT_EXPIRY;
+  return jwt.sign(payload, secret, { expiresIn });
+}
+
+function renderLoginView(res, status, model) {
+  return res.status(status).render('login', {
+    title: 'Login',
+    error: model.error || null,
+    values: model.values || { email: '' },
+    next: model.next || '/',
+  });
+}
+
+export function renderLogin(req, res) {
+  if (req.user) {
+    return res.redirect('/');
+  }
+
+  const nextPath = safeRedirect(req.query.next);
+  return renderLoginView(res, 200, {
+    values: { email: '' },
+    next: nextPath,
+  });
+}
+
+export async function login(req, res, next) {
+  try {
+    const { email, password, next: nextPathFromBody } = req.body;
+    const wantsJsonResponse = wantsJSON(req);
+
+    if (!email || !password) {
+      if (wantsJsonResponse) {
+        return res.status(400).json({ error: 'Email and password are required.' });
+      }
+      return renderLoginView(res, 400, {
+        error: 'Email and password are required.',
+        values: { email: email || '' },
+        next: safeRedirect(nextPathFromBody),
+      });
+    }
+
+    const result = await pool.query(
+      'SELECT id, email, password, full_name, role FROM users WHERE email = $1',
+      [email.toLowerCase()],
+    );
+
+    if (result.rowCount === 0) {
+      if (wantsJsonResponse) {
+        return res.status(401).json({ error: 'Invalid email or password.' });
+      }
+      return renderLoginView(res, 401, {
+        error: 'Invalid email or password.',
+        values: { email },
+        next: safeRedirect(nextPathFromBody),
+      });
+    }
+
+    const user = result.rows[0];
+    const passwordMatch = await bcrypt.compare(password, user.password);
+
+    if (!passwordMatch) {
+      if (wantsJsonResponse) {
+        return res.status(401).json({ error: 'Invalid email or password.' });
+      }
+      return renderLoginView(res, 401, {
+        error: 'Invalid email or password.',
+        values: { email },
+        next: safeRedirect(nextPathFromBody),
+      });
+    }
+
+    const tokenPayload = createTokenPayload(user);
+    const token = signToken(tokenPayload);
+    const redirectTarget = safeRedirect(nextPathFromBody);
+
+    const maxAge = Number(process.env.JWT_COOKIE_MAX_AGE_MS || 60 * 60 * 1000);
+    res.cookie(TOKEN_COOKIE_NAME, token, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge,
+    });
+
+    if (wantsJsonResponse) {
+      return res.json({ token, user: tokenPayload });
+    }
+
+    return res.redirect(redirectTarget);
+  } catch (error) {
+    if (error.message === 'JWT_SECRET is not configured') {
+      return next(error);
+    }
+    return next(error);
+  }
+}
+
+export function logout(req, res) {
+  res.clearCookie(TOKEN_COOKIE_NAME, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  });
+
+  if (wantsJSON(req)) {
+    return res.json({ success: true });
+  }
+
+  return res.redirect('/auth/login');
+}

--- a/db/dummy/002_init.sql
+++ b/db/dummy/002_init.sql
@@ -1,8 +1,8 @@
 -- Users
 INSERT INTO users (email, password, full_name, role)
 VALUES 
-('student1@university.edu', 'password123', 'Alice Nguyen', 'student'),
-('student2@university.edu', 'password123', 'Bob Tran', 'student');
+('student1@university.edu', '$2b$10$XB9jIwry11vPBpxS4oJtPuMmPahGNbMkMi3gr4rmyY5IOuVuXzwJS', 'Alice Nguyen', 'student'),
+('student2@university.edu', '$2b$10$XB9jIwry11vPBpxS4oJtPuMmPahGNbMkMi3gr4rmyY5IOuVuXzwJS', 'Bob Tran', 'student');
 
 -- Events
 INSERT INTO events (title, description, event_date, event_time, location, type, capacity)

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,64 @@
+import jwt from 'jsonwebtoken';
+
+function wantsJSON(req) {
+  const accept = req.headers.accept || '';
+  const contentType = req.headers['content-type'] || '';
+  return accept.includes('application/json') || contentType.includes('application/json');
+}
+
+function safeRedirect(target) {
+  if (!target) return '/';
+  if (target.startsWith('http://') || target.startsWith('https://')) {
+    return '/';
+  }
+  if (!target.startsWith('/')) {
+    return '/';
+  }
+  if (target.startsWith('//')) {
+    return '/';
+  }
+  return target;
+}
+
+export function attachUser(req, res, next) {
+  const authorization = req.headers.authorization || '';
+  const bearerToken = authorization.startsWith('Bearer ')
+    ? authorization.slice(7)
+    : null;
+  const token = req.cookies?.token || bearerToken;
+
+  if (!token) {
+    req.user = null;
+    res.locals.user = null;
+    return next();
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.user = decoded;
+    res.locals.user = decoded;
+  } catch (error) {
+    req.user = null;
+    res.locals.user = null;
+    if (req.cookies?.token) {
+      res.clearCookie('token');
+    }
+  }
+
+  next();
+}
+
+export function ensureAuthenticated(req, res, next) {
+  if (req.user) {
+    return next();
+  }
+
+  if (wantsJSON(req)) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const redirectTo = encodeURIComponent(safeRedirect(req.originalUrl));
+  return res.redirect(`/auth/login?next=${redirectTo}`);
+}
+
+export { safeRedirect };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "comp3028",
       "version": "0.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
         "cookie-parser": "~1.4.4",
         "debug": "~2.6.9",
         "dotenv": "^17.2.2",
         "ejs": "^3.1.10",
         "express": "^4.21.2",
         "http-errors": "~1.6.3",
+        "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
         "nodemon": "^3.1.10",
         "pg": "^8.16.3"
@@ -84,6 +86,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/binary-extensions": {
@@ -200,6 +211,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -415,6 +432,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -931,6 +957,97 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "dev": "nodemon app.js"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.2",
     "cookie-parser": "~1.4.4",
     "debug": "~2.6.9",
     "dotenv": "^17.2.2",
     "ejs": "^3.1.10",
     "express": "^4.21.2",
     "http-errors": "~1.6.3",
+    "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",
     "nodemon": "^3.1.10",
     "pg": "^8.16.3"

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -105,6 +105,31 @@ label.burger:hover {
   color: white;
   border-radius: 5px;
 }
+.sidebar ul li form.logout-form {
+  margin: 0;
+  display: block;
+}
+.logout-button {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: none;
+  border: none;
+  color: #000;
+  font-weight: bold;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  text-align: left;
+}
+.logout-button:hover {
+  background-color: #357abd;
+  color: #fff;
+}
+.logout-button .sidebar-icon {
+  pointer-events: none;
+}
 /* MAIN CONTENT */
 .main-content {
   margin-left: 6%;
@@ -124,6 +149,60 @@ label.burger:hover {
   #hamburger:checked ~ .main-content {
     margin-left: 20%;
   }
+}
+
+.form-card {
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 2rem;
+  max-width: 420px;
+  width: 100%;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+.form-card label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.form-card input[type="email"],
+.form-card input[type="password"] {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  margin-bottom: 1.25rem;
+  font-size: 1rem;
+}
+
+.form-card button[type="submit"] {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: #4a90e2;
+  border: none;
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.form-card button[type="submit"]:hover {
+  background: #357abd;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  margin-bottom: 1.25rem;
+}
+
+.alert-error {
+  background: #fee2e2;
+  color: #b91c1c;
+  border: 1px solid #fca5a5;
 }
 
 @media (max-width: 649px) {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import { login, logout, renderLogin } from '../controllers/auth.js';
+
+export const authRouter = express.Router();
+
+authRouter.get('/login', renderLogin);
+authRouter.post('/login', login);
+authRouter.post('/logout', logout);

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -8,8 +8,13 @@
     <%- include ('navigationBar/navBar') %>
     <div class="main-content">
     <h1><%= title %></h1>
-    <p>Welcome to <%= title %></p>  
-    <p>Example of how the page will be with new navbar</p>
+    <% if (user) { %>
+      <p>Welcome back, <strong><%= user.fullName %></strong>!</p>
+      <p>You are logged in as <%= user.email %>. Explore the dashboard to manage your events and wellbeing tools.</p>
+    <% } else { %>
+      <p>Welcome to <%= title %>.</p>
+      <p><a href="/auth/login">Log in</a> to access personalised resources, track your mood, and connect with campus life.</p>
+    <% } %>
     </div>
   </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= title %></title>
+    <link rel="stylesheet" href="/stylesheets/style.css" />
+  </head>
+  <body>
+    <%- include('navigationBar/navBar') %>
+    <div class="main-content">
+      <h1>Welcome back</h1>
+      <p>Please sign in to access your personalised CampusWell experience.</p>
+      <% if (error) { %>
+        <div class="alert alert-error"><%= error %></div>
+      <% } %>
+      <form method="POST" action="/auth/login" class="form-card">
+        <input type="hidden" name="next" value="<%= next %>" />
+        <label for="email">Email</label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          placeholder="student@university.edu"
+          value="<%= values.email %>"
+          required
+        />
+        <label for="password">Password</label>
+        <input
+          type="password"
+          id="password"
+          name="password"
+          placeholder="Enter your password"
+          required
+        />
+        <button type="submit">Sign in</button>
+      </form>
+    </div>
+  </body>
+</html>

--- a/views/navigationBar/navBar.ejs
+++ b/views/navigationBar/navBar.ejs
@@ -7,47 +7,57 @@
   <label for="hamburger" class="burger-inside">&#9776;</label>
   <h2>CampusWell</h2>
   <ul>
-  <li>
-    <a href="/dashboard" class="<%= currentPath === '/' ? 'active' : '' %>">
-      <img src="/image/dashboard.png" class="sidebar-icon"> Dashboard
-    </a>
-  </li>
-  <li>
-    <a href="/mood" class="<%= currentPath === '/mood' ? 'active' : '' %>">
-      <img src="/image/mood.png" class="sidebar-icon"> Mood Tracker
-    </a>
-  </li>
-  <li>
-    <a href="/resources" class="<%= currentPath === '/resources' ? 'active' : '' %>">
-      <img src="/image/search.png" class="sidebar-icon"> Search & Discovery
-    </a>
-  </li>
-  <li>
-    <a href="/profile" class="<%= currentPath === '/profile' ? 'active' : '' %>">
-      <img src="/image/social.png" class="sidebar-icon"> Social Networking
-    </a>
-  </li>
-  <li>
-    <a href="#" class="<%= currentPath === '/gamification' ? 'active' : '' %>">
-      <img src="/image/gamification.png" class="sidebar-icon"> Gamification
-    </a>
-  </li>
-  <li>
-    <a href="#" class="<%= currentPath === '/alerts' ? 'active' : '' %>">
-      <img src="/image/danger.png" class="sidebar-icon"> Alerts
-    </a>
-  </li>
-  <li>
-    <a href="/logout" class="<%= currentPath === '/profile' ? 'active' : '' %>">
-      <img src="/image/user.png" class="sidebar-icon"> Profile
-    </a>
-  </li>
-  <li>
-    <a href="/logout">
-      <img src="/image/exit.png" class="sidebar-icon"> Logout
-    </a>
-  </li>
-</ul>
+    <li>
+      <a href="/" class="<%= currentPath === '/' ? 'active' : '' %>">
+        <img src="/image/dashboard.png" class="sidebar-icon"> Dashboard
+      </a>
+    </li>
+    <li>
+      <a href="/mood" class="<%= currentPath === '/mood' ? 'active' : '' %>">
+        <img src="/image/mood.png" class="sidebar-icon"> Mood Tracker
+      </a>
+    </li>
+    <li>
+      <a href="/resources" class="<%= currentPath === '/resources' ? 'active' : '' %>">
+        <img src="/image/search.png" class="sidebar-icon"> Search & Discovery
+      </a>
+    </li>
+    <li>
+      <a href="/profile" class="<%= currentPath === '/profile' ? 'active' : '' %>">
+        <img src="/image/social.png" class="sidebar-icon"> Social Networking
+      </a>
+    </li>
+    <li>
+      <a href="#" class="<%= currentPath === '/gamification' ? 'active' : '' %>">
+        <img src="/image/gamification.png" class="sidebar-icon"> Gamification
+      </a>
+    </li>
+    <li>
+      <a href="#" class="<%= currentPath === '/alerts' ? 'active' : '' %>">
+        <img src="/image/danger.png" class="sidebar-icon"> Alerts
+      </a>
+    </li>
+    <% if (user) { %>
+      <li>
+        <a href="/profile" class="<%= currentPath === '/profile' ? 'active' : '' %>">
+          <img src="/image/user.png" class="sidebar-icon"> <%= user.fullName %>
+        </a>
+      </li>
+      <li>
+        <form method="POST" action="/auth/logout" class="logout-form">
+          <button type="submit" class="logout-button">
+            <img src="/image/exit.png" class="sidebar-icon" alt="" /> Logout
+          </button>
+        </form>
+      </li>
+    <% } else { %>
+      <li>
+        <a href="/auth/login" class="<%= currentPath === '/auth/login' ? 'active' : '' %>">
+          <img src="/image/user.png" class="sidebar-icon"> Login
+        </a>
+      </li>
+    <% } %>
+  </ul>
 </nav>
 <script>
   //Make the navbar responsive to window size (<650)


### PR DESCRIPTION
## Summary
- add JWT-backed login/logout controllers, router, and middleware that issue secure cookies and expose the signed-in user
- build a styled login view, update navigation/home content to reflect authentication state, and add bcrypt/JSON Web Token deps
- hash seeded user passwords and document required JWT environment variables for local configuration

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e234fdf5748330a2ef22aa570aa211